### PR TITLE
Fixed incorrect emoji tag for merges

### DIFF
--- a/package.json
+++ b/package.json
@@ -113,7 +113,7 @@
           ":sparkles:",
           ":sunrise_over_mountains:",
           ":tada:",
-          ":twisted_rightward_arrows:",
+          ":twisted_rightwards_arrows:",
           ":white_check_mark:",
           ":wrench:",
           ":zap:"
@@ -247,7 +247,7 @@
               "release": false
             },
             {
-              "type": ":twisted_rightward_arrows:",
+              "type": ":twisted_rightwards_arrows:",
               "release": false
             },
             {


### PR DESCRIPTION
Small typo lead to emoji tag for merge commits not being rendered. This commit fixes it.